### PR TITLE
Made AMQP factory service public

### DIFF
--- a/src/TreeHouse/QueueBundle/Resources/config/services.yml
+++ b/src/TreeHouse/QueueBundle/Resources/config/services.yml
@@ -1,44 +1,44 @@
 parameters:
-  tree_house.queue.driver.amqp.connection.class: 'AMQPConnection'
-  tree_house.queue.driver.amqp.channel.class: 'AMQPChannel'
-  tree_house.queue.driver.amqp.exchange.class: 'AMQPExchange'
-  tree_house.queue.driver.amqp.queue.class: 'AMQPQueue'
-  tree_house.queue.driver.amqp.provider.class: 'TreeHouse\Queue\Message\Provider\AmqpMessageProvider'
-  tree_house.queue.driver.amqp.publisher.class: 'TreeHouse\Queue\Message\Publisher\AmqpMessagePublisher'
-  tree_house.queue.driver.amqp.factory.class: 'TreeHouse\Queue\Factory\AmqpFactory'
-  tree_house.queue.composer.default.class: 'TreeHouse\Queue\Message\Composer\DefaultMessageComposer'
+  tree_house.queue.driver.amqp.connection.class: AMQPConnection
+  tree_house.queue.driver.amqp.channel.class: AMQPChannel
+  tree_house.queue.driver.amqp.exchange.class: AMQPExchange
+  tree_house.queue.driver.amqp.queue.class: AMQPQueue
+  tree_house.queue.driver.amqp.provider.class: TreeHouse\Queue\Message\Provider\AmqpMessageProvider
+  tree_house.queue.driver.amqp.publisher.class: TreeHouse\Queue\Message\Publisher\AmqpMessagePublisher
+  tree_house.queue.driver.amqp.factory.class: TreeHouse\Queue\Factory\AmqpFactory
+  tree_house.queue.composer.default.class: TreeHouse\Queue\Message\Composer\DefaultMessageComposer
 
 services:
   tree_house.queue.consumer.prototype:
     public: false
     abstract: true
-    class: 'TreeHouse\Queue\Consumer'
+    class: TreeHouse\Queue\Consumer
 
   tree_house.queue.driver.amqp.factory:
-    public: false
-    class: 'TreeHouse\Queue\Factory\AmqpFactory'
+    public: true
+    class: TreeHouse\Queue\Factory\AmqpFactory
 
   tree_house.queue.serializer.php:
     public: false
-    class: 'TreeHouse\Queue\Message\Serializer\PhpSerializer'
+    class: TreeHouse\Queue\Message\Serializer\PhpSerializer
 
   tree_house.queue.serializer.json:
     public: false
-    class: 'TreeHouse\Queue\Message\Serializer\JsonSerializer'
+    class: TreeHouse\Queue\Message\Serializer\JsonSerializer
 
   tree_house.queue.serializer.doctrine:
     public: false
-    class: 'TreeHouse\Queue\Message\Serializer\DoctrineSerializer'
+    class: TreeHouse\Queue\Message\Serializer\DoctrineSerializer
     arguments:
       - '@doctrine'
 
   tree_house.queue.event_listener.queue:
     public: true
-    class: 'TreeHouse\QueueBundle\EventListener\FlushListener'
+    class: TreeHouse\QueueBundle\EventListener\FlushListener
     tags:
-      - { name: 'kernel.event_listener', event: 'queue.flush', method: 'onFlush' }
+      - { name: kernel.event_listener, event: queue.flush, method: onFlush }
 
   tree_house.queue.flusher.doctrine_abstract:
     abstract: true
     public: false
-    class: 'TreeHouse\QueueBundle\Flusher\DoctrineFlusher'
+    class: TreeHouse\QueueBundle\Flusher\DoctrineFlusher


### PR DESCRIPTION
When trying to access an `amqp` provider during the `queue:consume` command; an exception is thrown about a missing service:
```
 [Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException]         
  You have requested a non-existent service "tree_house.queue.driver.amqp.factory".
```

This was a bit hard to trace but it seems the provider depends on the factory service to be available **after** compilation. Since the service is defined with `public: false`, this will trigger an exception.

Also removed all quotes where it is not necessary; consistent with definitions in our own projects


