### PR TITLE
Fix version constraint on queue lib

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "php":                 ">=5.5",
     "psr/log":             "~1.0",
     "symfony/symfony":     "~2.6",
-    "treehouselabs/queue": ">=v0.0.4"
+    "treehouselabs/queue": ">=v0.0.4,<0.1"
   },
   "require-dev": {
     "doctrine/orm":                 "~2.3",


### PR DESCRIPTION
Currently locking the bundle on ^v0.0.1, pulls versions of the queue library that it doesn't support (v0.1.0).

This PR fixes that. When merged we need to tag a version ~~v0.0.5.~~ v0.0.2