### PR TITLE
FlushListener not being triggered

### DIFF
--- a/src/TreeHouse/QueueBundle/DependencyInjection/TreeHouseQueueExtension.php
+++ b/src/TreeHouse/QueueBundle/DependencyInjection/TreeHouseQueueExtension.php
@@ -332,7 +332,7 @@ class TreeHouseQueueExtension extends Extension
         $definition = new DefinitionDecorator('tree_house.queue.consumer.prototype');
         $definition->addArgument(new Reference($queueId));
         $definition->addArgument(new Reference($processorId));
-        $definition->addArgument(new Reference('tree_house.queue.event_dispatcher'));
+        $definition->addArgument(new Reference('event_dispatcher'));
 
         $consumerId = sprintf('tree_house.queue.consumer.%s', $name);
         $container->setDefinition($consumerId, $definition);

--- a/src/TreeHouse/QueueBundle/Resources/config/services.yml
+++ b/src/TreeHouse/QueueBundle/Resources/config/services.yml
@@ -31,10 +31,6 @@ services:
     arguments:
       - '@doctrine'
 
-  tree_house.queue.event_dispatcher:
-    public: false
-    class: Symfony\Component\EventDispatcher\EventDispatcher
-
   tree_house.queue.event_listener.flush:
     public: true
     class: TreeHouse\QueueBundle\EventListener\FlushListener


### PR DESCRIPTION
Consumers are using a custom event dispatcher (`tree_house.queue.event_dispatcher`), causing the flush listener to never be triggered. 

The reason for this is that the flush listener has the tag `kernel.event_listener`, which is only used by the default `event_dispatcher` service (Symfony). 

NOTE: If using the Symfony dispatcher is not acceptable, we should create our own compiler pass to subscribe the flush listener separately (not in this PR).