### PR TITLE
Fix for declare command

### DIFF
--- a/src/TreeHouse/QueueBundle/Command/QueueDeclareCommand.php
+++ b/src/TreeHouse/QueueBundle/Command/QueueDeclareCommand.php
@@ -2,12 +2,28 @@
 
 namespace TreeHouse\QueueBundle\Command;
 
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use TreeHouse\QueueBundle\CacheWarmer\AmqpCacheWarmer;
 
-class QueueDeclareCommand extends ContainerAwareCommand
+class QueueDeclareCommand extends Command
 {
+    /**
+     * @var AmqpCacheWarmer
+     */
+    private $cacheWarmer;
+
+    /**
+     * @param AmqpCacheWarmer $cacheWarmer
+     */
+    public function __construct(AmqpCacheWarmer $cacheWarmer)
+    {
+        parent::__construct();
+
+        $this->cacheWarmer = $cacheWarmer;
+    }
+
     /**
      * @inheritdoc
      */
@@ -27,8 +43,7 @@ HELP
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $warmer = $this->getContainer()->get('tree_house.queue.cache.warmer.amqp');
-        $warmer->warmUp('');
+        $this->cacheWarmer->warmUp('');
 
         $output->writeln('<info>All exchanges and queues are declared</info>');
     }

--- a/src/TreeHouse/QueueBundle/Resources/config/services.yml
+++ b/src/TreeHouse/QueueBundle/Resources/config/services.yml
@@ -49,3 +49,11 @@ services:
       - '@service_container'
     tags:
       - { name: 'kernel.cache_warmer' }
+
+  tree_house.queue.command.queue.declare:
+    public: true
+    class: TreeHouse\QueueBundle\Command\QueueDeclareCommand
+    arguments:
+      - '@tree_house.queue.cache.warmer.amqp'
+    tags:
+      - { name: 'console.command' }


### PR DESCRIPTION
The cache warmer service is not public so it is not possible to retrieve it from the container. 

Instead of making it public I choose to make the command injectable so the service can stay private.