### PR TITLE
Consumer decorator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ For a complete list of releases, see the [releases page][0].
 [0]: https://github.com/treehouselabs/queue-bundle/releases
 
 
+## v0.2.0
+
+### Changes
+* Moved limiting logic from consume command to limiter classes
+* Moved most consuming logic from command to decorating Consumer class
+
+
 ## v0.1.0
 
 ### Changes

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "psr/log": "^1.0",
     "symfony/symfony": "^2.7|^3.0",
     "doctrine/orm": "^2.3",
-    "treehouselabs/queue": "^0.2"
+    "treehouselabs/queue": "^0.3"
   },
   "require-dev": {
     "ext-amqp": "^1.7",

--- a/src/TreeHouse/QueueBundle/Command/QueueConsumeCommand.php
+++ b/src/TreeHouse/QueueBundle/Command/QueueConsumeCommand.php
@@ -8,17 +8,12 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use TreeHouse\Queue\Consumer\ConsumerInterface;
-use TreeHouse\Queue\Event\ConsumeEvent;
-use TreeHouse\Queue\Event\ConsumeExceptionEvent;
-use TreeHouse\Queue\QueueEvents;
+use TreeHouse\QueueBundle\Consumer\Consumer;
+use TreeHouse\QueueBundle\Consumer\Limiter\MemoryLimiter;
+use TreeHouse\QueueBundle\Consumer\Limiter\MessagesLimiter;
 
 class QueueConsumeCommand extends ContainerAwareCommand
 {
-    /**
-     * @var OutputInterface
-     */
-    protected $output;
-
     /**
      * @inheritdoc
      */
@@ -30,7 +25,8 @@ class QueueConsumeCommand extends ContainerAwareCommand
         $this->addOption('limit', 'l', InputOption::VALUE_OPTIONAL, 'Maximum number of messages to consume. Set to 0 for indefinite consuming.', 0);
         $this->addOption('max-memory', 'm', InputOption::VALUE_OPTIONAL, 'Maximum amount of memory to use (in MB). The consumer will try to stop before this limit is reached. Set to 0 for indefinite consuming.', 0);
         $this->addOption('max-time', 't', InputOption::VALUE_OPTIONAL, 'Maximum execution time in seconds. Set to 0 for indefinite consuming', 0);
-        $this->addOption('wait', 'w', InputOption::VALUE_OPTIONAL, 'Time in microseconds to wait before polling the next message', 10000);
+        $this->addOption('wait', 'w', InputOption::VALUE_OPTIONAL, 'Time in microseconds to wait before consuming the next message', 0);
+        $this->addOption('min-duration', 'd', InputOption::VALUE_OPTIONAL, 'Duration that this command must run for', 15);
     }
 
     /**
@@ -39,211 +35,41 @@ class QueueConsumeCommand extends ContainerAwareCommand
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $name = $input->getArgument('queue');
-        $batchSize = intval($input->getOption('batch-size'));
-        $wait = intval($input->getOption('wait'));
-        $limit = intval($input->getOption('limit'));
-        $maxMemory = intval($input->getOption('max-memory')) * 1024 * 1024;
-        $maxTime = intval($input->getOption('max-time'));
 
-        $startTime = time();
-        $minDuration = 15;
+        /** @var ConsumerInterface $delegate */
+        $delegate = $this->getContainer()->get(sprintf('tree_house.queue.consumer.%s', $name));
+        $consumer = (new Consumer($delegate, $output, $this->getConsumerTag()))
+            ->waitBetweenMessages((int) $input->getOption('wait'))
+            ->flushAfter((int) $input->getOption('batch-size'))
+            ->mustRunFor((int) $input->getOption('min-duration'))
+        ;
 
-        $this->output = $output;
-        $this->output(sprintf('Consuming from <info>%s</info> queue', $name));
-
-        $consumer = $this->getConsumer($name);
-        $dispatcher = $consumer->getEventDispatcher();
-        $dispatcher->addListener(QueueEvents::CONSUME_MESSAGE, [$this, 'onConsumeMessage']);
-        $dispatcher->addListener(QueueEvents::CONSUMED_MESSAGE, [$this, 'onMessageConsumed']);
-        $dispatcher->addListener(QueueEvents::CONSUME_EXCEPTION, [$this, 'onConsumeException']);
-
-        $processed = 0;
-        while (true) {
-            try {
-                $consumer->consume();
-            } catch (\Exception $e) {
-                $this->output(
-                    sprintf('Uncaught %s thrown by consumer, shutting down gracefully', get_class($e)),
-                    $output::VERBOSITY_VERBOSE
-                );
-
-                $this->shutdown($consumer, $startTime, $minDuration);
-
-                throw $e;
-            }
-
-            // see if batch is completed
-            if (++$processed % $batchSize === 0) {
-                $this->output('Batch completed', OutputInterface::VERBOSITY_VERBOSE);
-                $this->flush($consumer);
-            }
-
-            // check for maximum number of processed messages
-            if (($limit > 0) && ($processed >= $limit)) {
-                $this->output(
-                    sprintf('Maximum number of messages consumed (%d)', $limit),
-                    $output::VERBOSITY_VERBOSE
-                );
-
-                break;
-            }
-
-            // check for max memory usage
-            if (($maxMemory > 0) && memory_get_usage(true) > $maxMemory) {
-                $this->output(
-                    sprintf('Memory peak of %dMB reached', $maxMemory / 1024 / 1024),
-                    $output::VERBOSITY_VERBOSE
-                );
-
-                break;
-            }
-
-            // check for execution time
-            if (($maxTime > 0) && ((time() - $startTime) > $maxTime)) {
-                $this->output(
-                    sprintf('Maximum execution time of %ds reached', $maxTime),
-                    $output::VERBOSITY_VERBOSE
-                );
-
-                break;
-            }
-
-            // cool down
-            usleep($wait);
+        if ($limit = (int) $input->getOption('limit')) {
+            $consumer->addLimiter(new MessagesLimiter($limit));
         }
 
-        $this->shutdown($consumer, $startTime, $minDuration);
-    }
-
-    /**
-     * @param ConsumeEvent $event
-     */
-    public function onConsumeMessage(ConsumeEvent $event)
-    {
-        $envelope = $event->getEnvelope();
-        $verbose = $this->output->getVerbosity() > OutputInterface::VERBOSITY_VERBOSE;
-
-        $this->output(
-            sprintf(
-                '<comment>[%s]</comment> Processing payload <info>%s</info>',
-                $envelope->getDeliveryTag(),
-                $this->getPayloadOutput($envelope->getBody(), 20, $verbose)
-            )
-        );
-    }
-
-    /**
-     * @param ConsumeEvent $event
-     */
-    public function onMessageConsumed(ConsumeEvent $event)
-    {
-        $envelope = $event->getEnvelope();
-
-        $this->output(
-            sprintf(
-                '<comment>[%s]</comment> processed with result: <info>%s</info>',
-                $envelope->getDeliveryTag(),
-                json_encode($event->getResult())
-            )
-        );
-    }
-
-    /**
-     * @param ConsumeExceptionEvent $event
-     */
-    public function onConsumeException(ConsumeExceptionEvent $event)
-    {
-        $envelope = $event->getEnvelope();
-        $exception = $event->getException();
-
-        $this->output(
-            sprintf(
-                '<comment>[%s]</comment> raised <info>%s</info>: <error>%s</error>',
-                $envelope->getDeliveryTag(),
-                get_class($exception),
-                $exception->getMessage()
-            )
-        );
-    }
-
-    /**
-     * @param string $name
-     *
-     * @return ConsumerInterface
-     */
-    private function getConsumer($name)
-    {
-        return $this->getContainer()->get(sprintf('tree_house.queue.consumer.%s', $name));
-    }
-
-    /**
-     * Dispatches flush event.
-     *
-     * @param ConsumerInterface $consumer
-     */
-    private function flush(ConsumerInterface $consumer)
-    {
-        $consumer->getEventDispatcher()->dispatch(QueueEvents::CONSUME_FLUSH);
-    }
-
-    /**
-     * @param string $message
-     * @param int    $threshold
-     */
-    private function output($message, $threshold = OutputInterface::VERBOSITY_NORMAL)
-    {
-        if ($this->output->getVerbosity() < $threshold) {
-            return;
+        if ($maxMemory = (int) $input->getOption('max-memory')) {
+            $consumer->addLimiter(new MemoryLimiter($maxMemory * 1024 * 1024));
         }
 
-        $this->output->writeln($message);
+        $output->writeln(sprintf('Consuming from <info>%s</info> queue', $name));
+
+        $consumer->consume();
+
+        $output->writeln(
+            sprintf(
+                'Consumed <info>%d</info> messages in <info>%s seconds</info>',
+                $consumer->getProcessed(),
+                $consumer->getDuration()
+            )
+        );
     }
 
     /**
-     * @param string $payload
-     * @param int    $offset
-     * @param bool   $fullPayload
-     *
      * @return string
      */
-    private function getPayloadOutput($payload, $offset = 0, $fullPayload = false)
+    private function getConsumerTag()
     {
-        if ($fullPayload === true) {
-            return $payload;
-        }
-
-        $width = (int) $this->getApplication()->getTerminalDimensions()[0] - $offset;
-        if ($width > 0 && mb_strwidth($payload, 'utf8') > $width) {
-            $payload = mb_substr($payload, 0, $width - 10) . '...';
-        }
-
-        return $payload;
-    }
-
-    /**
-     * @param ConsumerInterface $consumer
-     * @param int $startTime
-     * @param int $minDuration
-     */
-    private function shutdown($consumer, $startTime, $minDuration)
-    {
-        $this->output('Shutting down consumer');
-
-        // flush remaining changes
-        $this->flush($consumer);
-
-        // make sure consumer doesn't quit to quickly, or supervisor will mark it as a failed restart,
-        // and putting the process in FATAL state.
-        $duration = time() - $startTime;
-        if ($duration < $minDuration) {
-            $time = $minDuration - $duration;
-
-            $this->output(
-                sprintf('Sleeping for %d seconds so consumer has run for %d seconds', $time, $minDuration),
-                OutputInterface::VERBOSITY_VERBOSE
-            );
-
-            sleep($time);
-        }
+        return sprintf('%s-%s', $this->getName(), uniqid());
     }
 }

--- a/src/TreeHouse/QueueBundle/Consumer/Consumer.php
+++ b/src/TreeHouse/QueueBundle/Consumer/Consumer.php
@@ -68,6 +68,8 @@ class Consumer implements EventSubscriberInterface
         $this->consumer = $consumer;
         $this->output = $output;
         $this->consumerTag = $consumerTag;
+
+        $this->consumer->getEventDispatcher()->addSubscriber($this);
     }
 
     /**
@@ -155,8 +157,6 @@ class Consumer implements EventSubscriberInterface
      */
     public function consume()
     {
-        $this->consumer->getEventDispatcher()->addSubscriber($this);
-
         $this->startTime = time();
 
         try {

--- a/src/TreeHouse/QueueBundle/Consumer/Consumer.php
+++ b/src/TreeHouse/QueueBundle/Consumer/Consumer.php
@@ -77,6 +77,7 @@ class Consumer implements EventSubscriberInterface
     {
         return [
             QueueEvents::CONSUME_MESSAGE => 'onConsumeMessage',
+            QueueEvents::CONSUMED_MESSAGE => 'onMessageConsumed',
             QueueEvents::CONSUME_EXCEPTION => 'onConsumeException',
         ];
     }

--- a/src/TreeHouse/QueueBundle/Consumer/Consumer.php
+++ b/src/TreeHouse/QueueBundle/Consumer/Consumer.php
@@ -1,0 +1,309 @@
+<?php
+
+namespace TreeHouse\QueueBundle\Consumer;
+
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use TreeHouse\Queue\Consumer\ConsumerInterface;
+use TreeHouse\Queue\Event\ConsumeEvent;
+use TreeHouse\Queue\Event\ConsumeExceptionEvent;
+use TreeHouse\Queue\QueueEvents;
+use TreeHouse\QueueBundle\Consumer\Limiter\LimiterInterface;
+use TreeHouse\QueueBundle\Consumer\Limiter\LimitReachedException;
+
+class Consumer implements EventSubscriberInterface
+{
+    /**
+     * @var ConsumerInterface
+     */
+    private $consumer;
+
+    /**
+     * @var OutputInterface
+     */
+    private $output;
+
+    /**
+     * @var string
+     */
+    private $consumerTag;
+
+    /**
+     * @var LimiterInterface[]
+     */
+    private $limiters = [];
+
+    /**
+     * @var int
+     */
+    private $startTime;
+
+    /**
+     * @var int
+     */
+    private $minDuration = 15;
+
+    /**
+     * @var int
+     */
+    private $processed = 0;
+
+    /**
+     * @var int
+     */
+    private $batchSize = 25;
+
+    /**
+     * @var int
+     */
+    private $coolDownTime = 0;
+
+    /**
+     * @param ConsumerInterface $consumer
+     * @param OutputInterface   $output
+     * @param string           $consumerTag
+     */
+    public function __construct(ConsumerInterface $consumer, OutputInterface $output, $consumerTag = null)
+    {
+        $this->consumer = $consumer;
+        $this->output = $output;
+        $this->consumerTag = $consumerTag;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            QueueEvents::CONSUME_MESSAGE => 'onConsumeMessage',
+            QueueEvents::CONSUME_EXCEPTION => 'onConsumeException',
+        ];
+    }
+
+    /**
+     * @param LimiterInterface $limiter
+     */
+    public function addLimiter(LimiterInterface $limiter)
+    {
+        $this->limiters[] = $limiter;
+    }
+
+    /**
+     * @param int $duration
+     *
+     * @return $this
+     */
+    public function mustRunFor($duration)
+    {
+        $this->minDuration = $duration;
+
+        return $this;
+    }
+
+    /**
+     * @param int $batchSize
+     *
+     * @return $this
+     */
+    public function flushAfter($batchSize)
+    {
+        $this->batchSize = $batchSize;
+
+        return $this;
+    }
+
+    /**
+     * @param int $coolDownTime
+     *
+     * @return $this
+     */
+    public function waitBetweenMessages($coolDownTime)
+    {
+        $this->coolDownTime = $coolDownTime;
+
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getProcessed()
+    {
+        return $this->processed;
+    }
+
+    /**
+     * @return int
+     */
+    public function getStartTime()
+    {
+        return $this->startTime;
+    }
+
+    /**
+     * @return int
+     */
+    public function getDuration()
+    {
+        return time() - $this->startTime;
+    }
+
+    /**
+     * @throws \Exception
+     */
+    public function consume()
+    {
+        $this->consumer->getEventDispatcher()->addSubscriber($this);
+
+        $this->startTime = time();
+
+        try {
+            $this->consumer->consume($this->consumerTag);
+
+            $this->shutdown();
+        } catch (\Exception $e) {
+            $this->output->writeln(
+                sprintf('Uncaught %s thrown by consumer, shutting down gracefully', get_class($e)),
+                OutputInterface::VERBOSITY_VERBOSE
+            );
+
+            $this->shutdown();
+
+            throw $e;
+        }
+    }
+
+    /**
+     * @param ConsumeEvent $event
+     */
+    public function onConsumeMessage(ConsumeEvent $event)
+    {
+        $envelope = $event->getEnvelope();
+        $fullPayload = $this->output->getVerbosity() > OutputInterface::VERBOSITY_VERBOSE;
+
+        $this->output->writeln(
+            sprintf(
+                '<comment>[%s]</comment> Processing payload <info>%s</info>',
+                $envelope->getDeliveryTag(),
+                $this->getPayloadOutput($envelope->getBody(), $fullPayload)
+            )
+        );
+    }
+
+    /**
+     * @param ConsumeEvent $event
+     */
+    public function onMessageConsumed(ConsumeEvent $event)
+    {
+        $envelope = $event->getEnvelope();
+
+        $this->output->writeln(
+            sprintf(
+                '<comment>[%s]</comment> processed with result: <info>%s</info>',
+                $envelope->getDeliveryTag(),
+                json_encode($event->getResult())
+            )
+        );
+
+        // see if batch is completed
+        if (++$this->processed % $this->batchSize === 0) {
+            $this->flush();
+        }
+
+        try {
+            foreach ($this->limiters as $limiter) {
+                $limiter->limitReached($this);
+            }
+        } catch (LimitReachedException $e) {
+            $this->output->writeln(
+                $e->getMessage(),
+                OutputInterface::VERBOSITY_VERBOSE
+            );
+
+            $event->stopConsuming();
+        }
+
+        // cool down
+        usleep($this->coolDownTime);
+    }
+
+    /**
+     * @param ConsumeExceptionEvent $event
+     */
+    public function onConsumeException(ConsumeExceptionEvent $event)
+    {
+        $envelope = $event->getEnvelope();
+        $exception = $event->getException();
+
+        $this->output->writeln(
+            sprintf(
+                '<comment>[%s]</comment> raised <info>%s</info>: <error>"%s"</error>',
+                $envelope->getDeliveryTag(),
+                get_class($exception),
+                $exception->getMessage()
+            )
+        );
+    }
+
+    /**
+     * @param string $payload
+     * @param bool   $fullPayload
+     *
+     * @return string
+     */
+    private function getPayloadOutput($payload, $fullPayload = false)
+    {
+        if ($fullPayload === true) {
+            return $payload;
+        }
+
+        $maxWidth = 100;
+        if (mb_strwidth($payload, 'utf8') > $maxWidth) {
+            $payload = mb_substr($payload, 0, $maxWidth - 10) . '...';
+        }
+
+        return $payload;
+    }
+
+    /**
+     * Dispatches flush event.
+     */
+    private function flush()
+    {
+        $this->output->writeln(
+            'Batch completed, flushing',
+            OutputInterface::VERBOSITY_VERBOSE
+        );
+
+        $this->consumer->getEventDispatcher()->dispatch(QueueEvents::CONSUME_FLUSH);
+    }
+
+    /**
+     * Shutdown procedure
+     */
+    private function shutdown()
+    {
+        $this->output->writeln('Shutting down consumer');
+
+        // flush remaining changes
+        $this->flush();
+
+        // cancel the subscription with the queue
+        $this->consumer->cancel($this->consumerTag);
+
+        // make sure consumer doesn't quit to quickly, or supervisor will mark it as a failed restart,
+        // and putting the process in FATAL state.
+        $duration = $this->getDuration();
+        if ($duration < $this->minDuration) {
+            $remaining = $this->minDuration - $duration;
+
+            $this->output->writeln(
+                sprintf('Sleeping for %d seconds so consumer has run for %d seconds', $remaining, $this->minDuration),
+                OutputInterface::VERBOSITY_VERBOSE
+            );
+
+            sleep($remaining);
+        }
+    }
+}

--- a/src/TreeHouse/QueueBundle/Consumer/Limiter/LimitReachedException.php
+++ b/src/TreeHouse/QueueBundle/Consumer/Limiter/LimitReachedException.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace TreeHouse\QueueBundle\Consumer\Limiter;
+
+class LimitReachedException extends \RuntimeException
+{
+    /**
+     * @param string $message
+     *
+     * @return LimitReachedException
+     */
+    public static function withMessage($message)
+    {
+        return new self($message);
+    }
+}

--- a/src/TreeHouse/QueueBundle/Consumer/Limiter/LimiterInterface.php
+++ b/src/TreeHouse/QueueBundle/Consumer/Limiter/LimiterInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace TreeHouse\QueueBundle\Consumer\Limiter;
+
+use TreeHouse\QueueBundle\Consumer\Consumer;
+
+interface LimiterInterface
+{
+    /**
+     * @param Consumer $consumer
+     *
+     * @throws LimitReachedException
+     */
+    public function limitReached(Consumer $consumer);
+}

--- a/src/TreeHouse/QueueBundle/Consumer/Limiter/MemoryLimiter.php
+++ b/src/TreeHouse/QueueBundle/Consumer/Limiter/MemoryLimiter.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace TreeHouse\QueueBundle\Consumer\Limiter;
+
+use TreeHouse\QueueBundle\Consumer\Consumer;
+
+class MemoryLimiter implements LimiterInterface
+{
+    /**
+     * @var int
+     */
+    private $maxMemory;
+
+    /**
+     * @param int $maxMemory
+     */
+    public function __construct($maxMemory)
+    {
+        $this->maxMemory = (int) $maxMemory;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function limitReached(Consumer $consumer)
+    {
+        if (memory_get_usage(true) > $this->maxMemory) {
+            throw LimitReachedException::withMessage(
+                sprintf('Memory peak of %dMB reached', $this->maxMemory / 1024 / 1024)
+            );
+        }
+    }
+}

--- a/src/TreeHouse/QueueBundle/Consumer/Limiter/MessagesLimiter.php
+++ b/src/TreeHouse/QueueBundle/Consumer/Limiter/MessagesLimiter.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace TreeHouse\QueueBundle\Consumer\Limiter;
+
+use TreeHouse\QueueBundle\Consumer\Consumer;
+
+class MessagesLimiter implements LimiterInterface
+{
+    /**
+     * @var int
+     */
+    private $limit;
+
+    /**
+     * @param int $limit
+     */
+    public function __construct($limit)
+    {
+        $this->limit = (int) $limit;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function limitReached(Consumer $consumer)
+    {
+        if ($consumer->getProcessed() >= $this->limit) {
+            throw LimitReachedException::withMessage(
+                sprintf('Maximum number of messages consumed (%d)', $this->limit)
+            );
+        }
+    }
+}

--- a/src/TreeHouse/QueueBundle/Consumer/Limiter/TimeLimiter.php
+++ b/src/TreeHouse/QueueBundle/Consumer/Limiter/TimeLimiter.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace TreeHouse\QueueBundle\Consumer\Limiter;
+
+use TreeHouse\QueueBundle\Consumer\Consumer;
+
+class TimeLimiter implements LimiterInterface
+{
+    /**
+     * @var int
+     */
+    private $maxTime;
+
+    /**
+     * @param int $maxTime
+     */
+    public function __construct($maxTime)
+    {
+        $this->maxTime = (int) $maxTime;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function limitReached(Consumer $consumer)
+    {
+        if ($consumer->getDuration() >= $this->maxTime) {
+            throw LimitReachedException::withMessage(
+                sprintf('Maximum execution time of %ds reached', $this->maxTime)
+            );
+        }
+    }
+}

--- a/tests/src/TreeHouse/QueueBundle/Tests/Consumer/Limiter/MemoryLimiterTest.php
+++ b/tests/src/TreeHouse/QueueBundle/Tests/Consumer/Limiter/MemoryLimiterTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace TreeHouse\QueueBundle\Tests\Consumer\Limiter;
+
+use Mockery as Mock;
+use TreeHouse\QueueBundle\Consumer\Consumer;
+use TreeHouse\QueueBundle\Consumer\Limiter\LimitReachedException;
+use TreeHouse\QueueBundle\Consumer\Limiter\MemoryLimiter;
+
+class MemoryLimiterTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @test
+     */
+    public function it_can_reach_a_limit()
+    {
+        $limiter = new MemoryLimiter(1);
+        $consumer = Mock::mock(Consumer::class);
+
+        $this->expectException(LimitReachedException::class);
+
+        $limiter->limitReached($consumer);
+    }
+
+    /**
+     * @test
+     */
+    public function it_must_reach_a_limit()
+    {
+        $limiter = new MemoryLimiter(PHP_INT_MAX);
+        $consumer = Mock::mock(Consumer::class);
+
+        $this->assertNull(
+            $limiter->limitReached($consumer)
+        );
+    }
+}

--- a/tests/src/TreeHouse/QueueBundle/Tests/Consumer/Limiter/MessagesLimiterTest.php
+++ b/tests/src/TreeHouse/QueueBundle/Tests/Consumer/Limiter/MessagesLimiterTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace TreeHouse\QueueBundle\Tests\Consumer\Limiter;
+
+use Mockery as Mock;
+use TreeHouse\QueueBundle\Consumer\Consumer;
+use TreeHouse\QueueBundle\Consumer\Limiter\LimitReachedException;
+use TreeHouse\QueueBundle\Consumer\Limiter\MessagesLimiter;
+
+class MessagesLimiterTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @test
+     */
+    public function it_can_reach_a_limit()
+    {
+        $limiter = new MessagesLimiter(100);
+        $consumer = Mock::mock(Consumer::class);
+        $consumer->shouldReceive('getProcessed')->andReturn(100);
+
+        $this->expectException(LimitReachedException::class);
+
+        $limiter->limitReached($consumer);
+    }
+
+    /**
+     * @test
+     */
+    public function it_must_reach_a_limit()
+    {
+        $limiter = new MessagesLimiter(100);
+        $consumer = Mock::mock(Consumer::class);
+        $consumer->shouldReceive('getProcessed')->andReturn(99);
+
+        $this->assertNull(
+            $limiter->limitReached($consumer)
+        );
+    }
+}

--- a/tests/src/TreeHouse/QueueBundle/Tests/Consumer/Limiter/TimeLimiterTest.php
+++ b/tests/src/TreeHouse/QueueBundle/Tests/Consumer/Limiter/TimeLimiterTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace TreeHouse\QueueBundle\Tests\Consumer\Limiter;
+
+use Mockery as Mock;
+use TreeHouse\QueueBundle\Consumer\Consumer;
+use TreeHouse\QueueBundle\Consumer\Limiter\LimitReachedException;
+use TreeHouse\QueueBundle\Consumer\Limiter\TimeLimiter;
+
+class TimeLimiterTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @test
+     */
+    public function it_can_reach_a_limit()
+    {
+        $limiter = new TimeLimiter(10);
+        $consumer = Mock::mock(Consumer::class);
+        $consumer->shouldReceive('getDuration')->andReturn(10);
+
+        $this->expectException(LimitReachedException::class);
+
+        $limiter->limitReached($consumer);
+    }
+
+    /**
+     * @test
+     */
+    public function it_must_reach_a_limit()
+    {
+        $limiter = new TimeLimiter(10);
+        $consumer = Mock::mock(Consumer::class);
+        $consumer->shouldReceive('getDuration')->andReturn(9);
+
+        $this->assertNull(
+            $limiter->limitReached($consumer)
+        );
+    }
+}


### PR DESCRIPTION
Moved consuming logic to a decorating Consumer class. This is to properly use the (blocking) consume method from the AMQP driver, instead of replicating this behaviour in this command.

This in turn ensures a single consumer tag per consume command that is being run. Previously each message that was consumed resulted in a new consumer tag (!) which creates an unnecessary burden on the broker.