### PR TITLE
Remove already covered config constraint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,12 @@ For a complete list of releases, see the [releases page][0].
 
 [0]: https://github.com/treehouselabs/queue-bundle/releases
 
-## v 1.0.1
+## v1.0.2
+
+### Changes
+* Remove redundant and deprecated `canNotBeEmpty()` for configuration
+
+## v1.0.1
 
 ### Changes
 * Fix configuration for QueueConsumeCommand

--- a/src/TreeHouse/QueueBundle/DependencyInjection/Configuration.php
+++ b/src/TreeHouse/QueueBundle/DependencyInjection/Configuration.php
@@ -83,7 +83,6 @@ class Configuration implements ConfigurationInterface
             ->arrayNode('connections')
             ->isRequired()
             ->requiresAtLeastOneElement()
-            ->cannotBeEmpty()
             ->useAttributeAsKey('name')
             ->info('List of connections. The key becomes the connection name.')
             ->example(<<<EOF


### PR DESCRIPTION
When checking `requiresAtLeastOneElement()` it will automatically not be empty 😎.